### PR TITLE
Fix legends

### DIFF
--- a/R/plot_tree.R
+++ b/R/plot_tree.R
@@ -202,6 +202,7 @@ create_noninteractive_ggtree <- function(ggtree_data,
       name = "Cluster size",
       range = c(2, 16)
     ) +
+    ggplot2::guides(shape = "none") +
     ggplot2::ggtitle(glue::glue("{Sys.Date()}, colour: {branch_col}")) +
     ggplot2::theme(legend.position = "top")
 

--- a/R/plot_tree.R
+++ b/R/plot_tree.R
@@ -390,9 +390,11 @@ append_heatmap <- function(ggobj,
     offset = 0.0005,
     colnames_angle = -90,
     colnames_position = "top",
-    colnames_offset_y = heatmap_lab_offset,
-    legend_title = "Genotype"
-  )
+    colnames_offset_y = heatmap_lab_offset
+  ) +
+    ggplot2::guides(
+      fill = ggplot2::guide_legend(title = "Genotype", nrow = 2)
+    )
 }
 
 #' Converts a \code{ggtree} object into a \code{ggiraph} object with interactive potential


### PR DESCRIPTION
These changes modify the legends in the tfpscanner output.

The legend in the original figure looks like this:

![image](https://github.com/jumpingrivers/tfpscanner/assets/7734886/a78f0369-ef53-417f-8335-c39de38b49e2)

The updated legend looks like this:

![image](https://github.com/jumpingrivers/tfpscanner/assets/7734886/f146c896-da49-4057-b6e6-ec4793e12c4e)

...

The original includes this non-annotated legend series (these icons differentiate internal nodes from leaves in the dendrogram). The updated legend does not include this series:

![image](https://github.com/jumpingrivers/tfpscanner/assets/7734886/7a54d880-17cb-4a19-bc4a-8102e552828b)

Heatmap genotypes were annotated using a horizontal legend in the original (though there was not much horizontal space for this; and this caused the legends to be truncated when presented in tfpbrowser). The updated legend stacks FALSE/TRUE vertically:

![image](https://github.com/jumpingrivers/tfpscanner/assets/7734886/b6d7b43d-1380-472c-8408-a7c5f7091935)

...

