### PR TITLE
Fix heatmap

### DIFF
--- a/R/plot_tree.R
+++ b/R/plot_tree.R
@@ -10,11 +10,10 @@
 #'   \code{lins$node_names} a string vector giving the name of the lineage. For \code{nodes} and
 #'   \code{node_names} the order of entries matches that for \code{lins}.
 #' @param   sc0,cmuts   Data-frames.
-#' @param   heatmap_width,heatmap_offset,heatmap_lab_offset    Parameters for positioning of the
-#'   heatmap.
 #' @param   mut_regex   Regular expression. Defines the mutations under study here.
 #' @param   colours    Vector of colours.
 #' @param   colour_limits   Min and max values for the colours.
+#' @inheritParams   treeview
 #'
 #' @return  A list with several entries. Each entry is a \code{ggtree} object. The list names are
 #'   "noninteractive", "with_interactivity_data", "with_heatmap", "interactive".
@@ -28,6 +27,7 @@ create_trees <- function(ggtree_data,
                          heatmap_width,
                          heatmap_offset,
                          heatmap_lab_offset,
+                         heatmap_fill = c("FALSE" = "grey90", "TRUE" = "grey70"),
                          mut_regex = NULL,
                          colours = NULL,
                          colour_limits = NULL) {
@@ -67,7 +67,7 @@ create_trees <- function(ggtree_data,
     heatmap_width = heatmap_width,
     heatmap_offset = heatmap_offset,
     heatmap_lab_offset = heatmap_lab_offset,
-    heatmap_fill = c("FALSE" = "grey90", "TRUE" = "grey70")
+    heatmap_fill = heatmap_fill
   )
 
   tree_list$interactive <- create_interactive_ggtree(
@@ -388,7 +388,7 @@ append_heatmap <- function(ggobj,
                            heatmap_width = 1,
                            heatmap_offset = 5,
                            heatmap_lab_offset = 0,
-                           heatmap_fill = c("FALSE" = "grey85", "TRUE" = "grey50")) {
+                           heatmap_fill = c("FALSE" = "grey90", "TRUE" = "grey70")) {
   ggtree::gheatmap(
     p = ggobj,
     data = genotype,

--- a/R/plot_tree.R
+++ b/R/plot_tree.R
@@ -10,7 +10,8 @@
 #'   \code{lins$node_names} a string vector giving the name of the lineage. For \code{nodes} and
 #'   \code{node_names} the order of entries matches that for \code{lins}.
 #' @param   sc0,cmuts   Data-frames.
-#' @param   heatmap_width,heatmap_lab_offset    Parameters for positioning of the heatmap.
+#' @param   heatmap_width,heatmap_offset,heatmap_lab_offset    Parameters for positioning of the
+#'   heatmap.
 #' @param   mut_regex   Regular expression. Defines the mutations under study here.
 #' @param   colours    Vector of colours.
 #' @param   colour_limits   Min and max values for the colours.
@@ -25,6 +26,7 @@ create_trees <- function(ggtree_data,
                          sc0,
                          cmuts,
                          heatmap_width,
+                         heatmap_offset,
                          heatmap_lab_offset,
                          mut_regex = NULL,
                          colours = NULL,
@@ -63,6 +65,7 @@ create_trees <- function(ggtree_data,
     ggobj = tree_list[["with_interactivity_data"]],
     genotype = genotype,
     heatmap_width = heatmap_width,
+    heatmap_offset = heatmap_offset,
     heatmap_lab_offset = heatmap_lab_offset
   )
 
@@ -382,12 +385,13 @@ extract_genotype_data <- function(ggobj,
 append_heatmap <- function(ggobj,
                            genotype,
                            heatmap_width = 1,
+                           heatmap_offset = 5,
                            heatmap_lab_offset = 0) {
   ggtree::gheatmap(
     p = ggobj,
     data = genotype,
     width = heatmap_width,
-    offset = 0.0005,
+    offset = heatmap_offset,
     colnames_angle = -90,
     colnames_position = "top",
     colnames_offset_y = heatmap_lab_offset

--- a/R/plot_tree.R
+++ b/R/plot_tree.R
@@ -202,6 +202,7 @@ create_noninteractive_ggtree <- function(ggtree_data,
       name = "Cluster size",
       range = c(2, 16)
     ) +
+    ggplot2::guides(shape = "none") +
     ggplot2::ggtitle(glue::glue("{Sys.Date()}, colour: {branch_col}")) +
     ggplot2::theme(legend.position = "top")
 

--- a/R/plot_tree.R
+++ b/R/plot_tree.R
@@ -66,7 +66,8 @@ create_trees <- function(ggtree_data,
     genotype = genotype,
     heatmap_width = heatmap_width,
     heatmap_offset = heatmap_offset,
-    heatmap_lab_offset = heatmap_lab_offset
+    heatmap_lab_offset = heatmap_lab_offset,
+    heatmap_fill = c("FALSE" = "grey90", "TRUE" = "grey70")
   )
 
   tree_list$interactive <- create_interactive_ggtree(
@@ -386,7 +387,8 @@ append_heatmap <- function(ggobj,
                            genotype,
                            heatmap_width = 1,
                            heatmap_offset = 5,
-                           heatmap_lab_offset = 0) {
+                           heatmap_lab_offset = 0,
+                           heatmap_fill = c("FALSE" = "grey85", "TRUE" = "grey50")) {
   ggtree::gheatmap(
     p = ggobj,
     data = genotype,
@@ -396,6 +398,9 @@ append_heatmap <- function(ggobj,
     colnames_position = "top",
     colnames_offset_y = heatmap_lab_offset
   ) +
+    ggplot2::scale_fill_manual(
+      values = heatmap_fill
+    ) +
     ggplot2::guides(
       fill = ggplot2::guide_legend(title = "Genotype", nrow = 2)
     )

--- a/R/plot_tree.R
+++ b/R/plot_tree.R
@@ -390,9 +390,11 @@ append_heatmap <- function(ggobj,
     offset = 0.0005,
     colnames_angle = -90,
     colnames_position = "top",
-    colnames_offset_y = heatmap_lab_offset,
-    legend_title = "Genotype"
-  )
+    colnames_offset_y = heatmap_lab_offset
+  ) +
+    ggplot2::guides(
+      fill = ggplot2::guide_legend(title = "Genotype", nrow = 2)
+    )
 }
 
 #' Converts a \code{ggtree} object into a \code{ggiraph} object with interactive potential

--- a/R/treeview.R
+++ b/R/treeview.R
@@ -15,8 +15,9 @@
 #'   format(s) should the interactive plots be saved? For \code{rds}, a \code{ggtree} or
 #'   \code{ggplot2} object will be placed in \code{rds} files. For \code{html}, \code{htmlwidget}s
 #'   will be placed in a \code{html} file.
-#' @param heatmap_width,heatmap_lab_offset Width and label-offset parameters for the constructed
+#' @param heatmap_width,heatmap_offset   Width relative to the tree and offset from the tree for the
 #'   heatmap.
+#' @param heatmap_lab_offset   Label-offset parameter for the constructed heatmap.
 #'
 #' @importFrom rlang .data
 #'
@@ -31,6 +32,7 @@ treeview <- function(e0,
                      output_dir = "treeview",
                      output_format = c("rds", "html"),
                      heatmap_width = .075,
+                     heatmap_offset = 8,
                      heatmap_lab_offset = -6) {
   output_format <- match.arg(output_format, several.ok = TRUE)
 
@@ -236,6 +238,7 @@ treeview <- function(e0,
       mut_regex = mutations,
       colours = cols,
       heatmap_width = heatmap_width,
+      heatmap_offset = heatmap_offset,
       heatmap_lab_offset = heatmap_lab_offset
     )
   }

--- a/R/treeview.R
+++ b/R/treeview.R
@@ -18,6 +18,9 @@
 #' @param heatmap_width,heatmap_offset   Width relative to the tree and offset from the tree for the
 #'   heatmap.
 #' @param heatmap_lab_offset   Label-offset parameter for the constructed heatmap.
+#' @param   heatmap_fill   Colours for filling the interior of the heatmap (which indicates the
+#'   presence / absence of a particular genotype). By default this is light grey for `FALSE` and
+#'   mid-grey for `TRUE`.
 #'
 #' @importFrom rlang .data
 #'
@@ -33,7 +36,8 @@ treeview <- function(e0,
                      output_format = c("rds", "html"),
                      heatmap_width = .075,
                      heatmap_offset = 8,
-                     heatmap_lab_offset = -6) {
+                     heatmap_lab_offset = -6,
+                     heatmap_fill = c("FALSE" = "grey90", "TRUE" = "grey70")) {
   output_format <- match.arg(output_format, several.ok = TRUE)
 
   # require logistic growth rate, prevent non-empty

--- a/man/append_heatmap.Rd
+++ b/man/append_heatmap.Rd
@@ -4,14 +4,21 @@
 \alias{append_heatmap}
 \title{Adds a heatmap to the right of a ggtree object}
 \usage{
-append_heatmap(ggobj, genotype, heatmap_width = 1, heatmap_lab_offset = 0)
+append_heatmap(
+  ggobj,
+  genotype,
+  heatmap_width = 1,
+  heatmap_offset = 5,
+  heatmap_lab_offset = 0
+)
 }
 \arguments{
 \item{ggobj}{A ggtree object.}
 
 \item{genotype}{The heatmap data.}
 
-\item{heatmap_width, heatmap_lab_offset}{Parameters for positioning of the heatmap.}
+\item{heatmap_width, heatmap_offset, heatmap_lab_offset}{Parameters for positioning of the
+heatmap.}
 }
 \value{
 A \code{ggtree} / \code{gg} / \code{ggplot} object with an appended heatmap.

--- a/man/append_heatmap.Rd
+++ b/man/append_heatmap.Rd
@@ -9,7 +9,8 @@ append_heatmap(
   genotype,
   heatmap_width = 1,
   heatmap_offset = 5,
-  heatmap_lab_offset = 0
+  heatmap_lab_offset = 0,
+  heatmap_fill = c(`FALSE` = "grey90", `TRUE` = "grey70")
 )
 }
 \arguments{
@@ -17,8 +18,14 @@ append_heatmap(
 
 \item{genotype}{The heatmap data.}
 
-\item{heatmap_width, heatmap_offset, heatmap_lab_offset}{Parameters for positioning of the
+\item{heatmap_width, heatmap_offset}{Width relative to the tree and offset from the tree for the
 heatmap.}
+
+\item{heatmap_lab_offset}{Label-offset parameter for the constructed heatmap.}
+
+\item{heatmap_fill}{Colours for filling the interior of the heatmap (which indicates the
+presence / absence of a particular genotype). By default this is light grey for `FALSE` and
+mid-grey for `TRUE`.}
 }
 \value{
 A \code{ggtree} / \code{gg} / \code{ggplot} object with an appended heatmap.

--- a/man/create_trees.Rd
+++ b/man/create_trees.Rd
@@ -14,6 +14,7 @@ create_trees(
   heatmap_width,
   heatmap_offset,
   heatmap_lab_offset,
+  heatmap_fill = c(`FALSE` = "grey90", `TRUE` = "grey70"),
   mut_regex = NULL,
   colours = NULL,
   colour_limits = NULL
@@ -35,8 +36,14 @@ vector of node numbers, these correspond to nodes in \code{ggtree_data$node}.
 
 \item{sc0, cmuts}{Data-frames.}
 
-\item{heatmap_width, heatmap_offset, heatmap_lab_offset}{Parameters for positioning of the
+\item{heatmap_width, heatmap_offset}{Width relative to the tree and offset from the tree for the
 heatmap.}
+
+\item{heatmap_lab_offset}{Label-offset parameter for the constructed heatmap.}
+
+\item{heatmap_fill}{Colours for filling the interior of the heatmap (which indicates the
+presence / absence of a particular genotype). By default this is light grey for `FALSE` and
+mid-grey for `TRUE`.}
 
 \item{mut_regex}{Regular expression. Defines the mutations under study here.}
 

--- a/man/create_trees.Rd
+++ b/man/create_trees.Rd
@@ -12,6 +12,7 @@ create_trees(
   sc0,
   cmuts,
   heatmap_width,
+  heatmap_offset,
   heatmap_lab_offset,
   mut_regex = NULL,
   colours = NULL,
@@ -34,7 +35,8 @@ vector of node numbers, these correspond to nodes in \code{ggtree_data$node}.
 
 \item{sc0, cmuts}{Data-frames.}
 
-\item{heatmap_width, heatmap_lab_offset}{Parameters for positioning of the heatmap.}
+\item{heatmap_width, heatmap_offset, heatmap_lab_offset}{Parameters for positioning of the
+heatmap.}
 
 \item{mut_regex}{Regular expression. Defines the mutations under study here.}
 

--- a/man/treeview.Rd
+++ b/man/treeview.Rd
@@ -12,6 +12,7 @@ treeview(
   output_dir = "treeview",
   output_format = c("rds", "html"),
   heatmap_width = 0.075,
+  heatmap_offset = 8,
   heatmap_lab_offset = -6
 )
 }
@@ -34,8 +35,10 @@ format(s) should the interactive plots be saved? For \code{rds}, a \code{ggtree}
 \code{ggplot2} object will be placed in \code{rds} files. For \code{html}, \code{htmlwidget}s
 will be placed in a \code{html} file.}
 
-\item{heatmap_width, heatmap_lab_offset}{Width and label-offset parameters for the constructed
+\item{heatmap_width, heatmap_offset}{Width relative to the tree and offset from the tree for the
 heatmap.}
+
+\item{heatmap_lab_offset}{Label-offset parameter for the constructed heatmap.}
 }
 \value{
 A \code{ggtree} plot.

--- a/man/treeview.Rd
+++ b/man/treeview.Rd
@@ -13,7 +13,8 @@ treeview(
   output_format = c("rds", "html"),
   heatmap_width = 0.075,
   heatmap_offset = 8,
-  heatmap_lab_offset = -6
+  heatmap_lab_offset = -6,
+  heatmap_fill = c(`FALSE` = "grey90", `TRUE` = "grey70")
 )
 }
 \arguments{
@@ -39,6 +40,10 @@ will be placed in a \code{html} file.}
 heatmap.}
 
 \item{heatmap_lab_offset}{Label-offset parameter for the constructed heatmap.}
+
+\item{heatmap_fill}{Colours for filling the interior of the heatmap (which indicates the
+presence / absence of a particular genotype). By default this is light grey for `FALSE` and
+mid-grey for `TRUE`.}
 }
 \value{
 A \code{ggtree} plot.


### PR DESCRIPTION
Builds on #25 

Here we modify the heatmap that sits alongside the dendrograms, in the tree-view outputs from tfpscanner.

The heatmap represents a discrete variable (TRUE/FALSE for the presence/absence of a genotype in a given virus strain). `ggtree::gheatmap()` was used to create the heatmap (and does the non-trivial task of aligning the heatmap rows with the corresponding strains in the dendrogram). gheatmap has some arguments for changing heatmap colours - but these are strictly for continuous variables (high, low and midpoint) - they have no effect on heatmaps for discrete variables. gheatmap is based on ggplot2, and so uses the ggplot2 defaults for filling discrete variables. These are cyan/peach and clash with every other colour-scheme, and the dendrogram branches do need to be coloured. For representing TRUE/FALSE, a more neutral colour choice is required - so we used a light and mid grey for FALSE and TRUE, respectively. The black text for the heatmap labels is visible over the mid grey.

I did experiment with using alternative colour text in the heatmap labels, but black seemed most visible. It wasn't possible to put a transparency behind the label text (the labels are built using geom_text; geom_label would be able to do this, but we don't have access to geom_label here because the use of geom_text is built into gheatmap()).

We found that the heatmap and dendrogram sometimes overlap in the output figures. So a `heatmap_offset` argument has been added to `treeview()` allowing the user to modify the distance between the dendrogram and the heatmap.